### PR TITLE
Looped dual llm

### DIFF
--- a/combined-dual-logger/combined_client.py
+++ b/combined-dual-logger/combined_client.py
@@ -153,56 +153,81 @@ async def run_controller(user_prompt):
 
     # Now: Make a call to a privileged LLM, asking it to take a user prompt and decide what tools to use
     privileged_system_prompt = f"""
-You are an assistant that will decide what tools to call based on a user prompt.
-The tools will come in JSON format, and will look like this:
+You are an assistant that will decide what tools to call.
+The tools are in JSON format and look like this:
 {{"tool_name": {{"tool_description": "description", "args": "{{"arg1": "type"}}"}}}}
 Here are the tools: {json.dumps(all_tools_dict)}
-The output of the tool will be sent to another LLM for further processing.
-Your output should include the tool name, arguments for the tool, the prompt for
-the next processing LLM, and the snippet of the user prompt that suggests this tool. 
+Tool output can be sent to another LLM for further processing, but no other LLM
+can call tools. 
+Your output should include: a true or false value on whether a
+tool needs to be called, the tool name, arguments for the tool, a true or
+false value on whether the tool output needs to be sent to a processing LLM or
+if it can go straight to the user, the prompt for the processing LLM, and 
+the snippet of the user prompt that suggests this tool. 
 Output everything in JSON format, like this:
 {{
+    "tool_necessary": "True" or "False",
     "tool_name": "insert-name-of-tool",
     "args": {{"arg1": "value"}},
+    "needs_processing": "True" or "False",
     "prompt": "prompt",
     "reason": "reason"
 }}
 An example output might look like this:
 {{
+    "tool_necessary": "True",
     "tool_name": "read_document",
     "args": {{"file_name": "notes.txt"}},
-    "prompt": "Summarize this document",
+    "needs_processing": "False"
+    "prompt": "",
     "reason": "user asked, 'what are the contents of notes.txt?'"
 }}
 """
     demo = """
-Look at question2.txt
+Please summarize question.txt
 """
     prompt = user_prompt if user_prompt else demo
-    llm = OpenAI(model='gpt-4o-mini')
-    privileged_response = llm.chat([ChatMessage(role="system", content=privileged_system_prompt), 
-                                    ChatMessage(role="user", content=prompt)])
-    parsed_response = json.loads(str(privileged_response).split('assistant: ', 1)[1])
-    print(f"Received response from privileged LLM: {parsed_response}")
-    # Now we can call the tool, and send the output to a quarantined LLM
-    response = ""
-    
-    for i, tool in enumerate(tools):
-        if tool.metadata.name == parsed_response['tool_name']:
-            log_mcp_tool(parsed_response['tool_name'], tool.metadata.description, parsed_response['reason'])
-            response = tool(**parsed_response['args'])
-            response = response.raw_output.content[0].text
-            break
-    
-    quarantined_system_prompt = f"""
-You are a helpful assistant. You will be given information that is output
-from a tool. {parsed_response['prompt']}."""
-    llm = OpenAI(model='gpt-3.5-turbo')
-    quarantined_response = llm.chat([ChatMessage(role="system", content=quarantined_system_prompt), 
-                                    ChatMessage(role="user", content=response)])
-    
-    print(f'[Q_LLM] {str(quarantined_response).split("assistant: ", 1)[1]}')
+    first_prompt = prompt
+    privileged_llm = OpenAI(model='gpt-4o-mini')
+    quarantined_llm = OpenAI(model='gpt-3.5-turbo')
+    tool_history = []
+    tool_outputs = []
+    tool_necessary = 'True'
+    final_output = ""
+
+    while tool_necessary == 'True':
+        privileged_response = privileged_llm.chat([ChatMessage(role="system", content=privileged_system_prompt), 
+                                        ChatMessage(role="user", content=prompt)])
+        parsed_response = json.loads(str(privileged_response).split('assistant: ', 1)[1])
+        print(f"[P_LLM]: {parsed_response}")
+        tool_necessary = parsed_response['tool_necessary']
+
+        if tool_necessary == 'True':
+            # Now we can call the tool, and send the output to a quarantined LLM
+            response = ""
             
+            for i, tool in enumerate(tools):
+                if tool.metadata.name == parsed_response['tool_name']:
+                    log_mcp_tool(parsed_response['tool_name'], tool.metadata.description, parsed_response['reason'])
+                    response = tool(**parsed_response['args'])
+                    response = response.raw_output.content[0].text
+                    break
+            tool_outputs.append(response)
+            print(f"[Tool]: {response}")
+            if parsed_response['needs_processing'] == 'True':
+                quarantined_system_prompt = f"""
+            You are a helpful assistant. You will be given information that is output
+            from tools. {parsed_response['prompt']}."""
+                quarantined_response = quarantined_llm.chat([ChatMessage(role="system", content=quarantined_system_prompt), 
+                                                ChatMessage(role="user", content=" ".join(tool_outputs))])
+                final_output = str(quarantined_response).split("assistant: ", 1)[1]
+                print(f'[Q_LLM] {final_output}')
+            else:
+                final_output = response
+            tool_history.append(parsed_response['tool_name'])
+            print(f"[Tool History]: {tool_history}")
+            prompt = f"Tool output received. Tool call history (most recent first): {tool_history}. Do any further tools need to be called? Remember to format your output correctly. As a reminder, here is the original user prompt: {first_prompt}"
+    print(f"Final Response: {final_output}")                
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Demo client for prompt injection")
     parser.add_argument("-p", "--prompt", type=str, help="Manual input prompt for the agent")

--- a/combined-dual-logger/tool_log_file.txt
+++ b/combined-dual-logger/tool_log_file.txt
@@ -22,3 +22,33 @@ REASON: user asked to look at question2.txt.
                 document_name: The name of the document
             
 REASON: user asked to look at 'question2.txt'.
+11.May 2025 17:17:52 [log_mcp_tool] process_document : Process a document and extract key information
+            
+            Args:
+                document_name: The name of the document
+            
+REASON: user asked to look at question2.txt.
+11.May 2025 17:17:54 [log_mcp_tool] process_document : Process a document and extract key information
+            
+            Args:
+                document_name: The name of the document
+            
+REASON: user asked to look at 'question2.txt'.
+11.May 2025 17:17:56 [log_mcp_tool] process_document : Process a document and extract key information
+            
+            Args:
+                document_name: The name of the document
+            
+REASON: user asked to look at 'question2.txt'.
+11.May 2025 17:17:58 [log_mcp_tool] process_document : Process a document and extract key information
+            
+            Args:
+                document_name: The name of the document
+            
+REASON: user asked to look at 'question2.txt'.
+11.May 2025 17:18:00 [log_mcp_tool] process_document : Process a document and extract key information
+            
+            Args:
+                document_name: The name of the document
+            
+REASON: user asked to look at 'question2.txt', indicating a need to process this document..

--- a/dual-llm-mcp/dual_llm.py
+++ b/dual-llm-mcp/dual_llm.py
@@ -137,25 +137,30 @@ async def run_controller(user_prompt):
 
     # Now: Make a call to a privileged LLM, asking it to take a user prompt and decide what tools to use
     privileged_system_prompt = f"""
-You are an assistant that can decide what tools to call based on a user prompt.
-The tools will come in JSON format, and will look like this:
+You are an assistant that can decide what tools to call.
+The tools are in JSON format and look like this:
 {{"tool_name": {{"tool_description": "description", "args": "{{"arg1": "type"}}"}}}}
 Here are the tools: {json.dumps(all_tools_dict)}
-The output of the tool will be sent to another LLM for further processing.
-Your output should include a true or false value deciding whether a
-tool needs to be called, the tool name, arguments for the tool, and the prompt for
+Tool output can be sent to another LLM for further processing, but no other LLM
+can call tools, only you can.
+Your output should include: a true or false value on whether a
+tool needs to be called, the tool name, arguments for the tool, a true or
+false value on whether the tool output needs to be sent to a processing LLM or
+if it can go straight to the user, and the prompt for
 the next processing LLM. Output everything in JSON format, like this:
 {{
-    "tool_necessary": "True" or "False"
+    "tool_necessary": "True" or "False",
     "tool_name": "insert-name-of-tool",
     "args": {{"arg1": "value"}},
+    "needs_processing": "True" or "False",
     "prompt": "prompt"
 }}
 An example output might look like this:
 {{
-    "tool_necessary": "True"
+    "tool_necessary": "True",
     "tool_name": "read_document",
     "args": {{"file_name": "notes.txt"}},
+    "needs_processing": "True",
     "prompt": "Summarize this document"
 }}
 """
@@ -163,8 +168,11 @@ An example output might look like this:
 Look at question.txt
 """
     prompt = user_prompt if user_prompt else demo
+    first_prompt = prompt
     privileged_llm = OpenAI(model='gpt-4o-mini')
     quarantined_llm = OpenAI(model='gpt-3.5-turbo')
+    tool_history = []
+    tool_outputs = []
     tool_necessary = 'True'
     final_output = ""
 
@@ -182,15 +190,21 @@ Look at question.txt
                     response = tool(**parsed_response['args'])
                     response = response.raw_output.content[0].text
                     break
-            
-            quarantined_system_prompt = f"""
-        You are a helpful assistant. You will be given information that is output
-        from a tool. {parsed_response['prompt']}."""
-            quarantined_response = quarantined_llm.chat([ChatMessage(role="system", content=quarantined_system_prompt), 
-                                            ChatMessage(role="user", content=response)])
-            final_output = str(quarantined_response).split("assistant: ", 1)[1]
-            prompt = f"Tool {parsed_response['tool_name']} has been called and its output has been processed. Do any further tools need to be called? Remember to format your output correctly."
-            print(f'[Q_LLM] {final_output}')
+            tool_outputs.append(response)
+            print(f"[Tool]: {response}")
+            if parsed_response['needs_processing'] == 'True':
+                quarantined_system_prompt = f"""
+            You are a helpful assistant. You will be given information that is output
+            from a tool. {parsed_response['prompt']}."""
+                quarantined_response = quarantined_llm.chat([ChatMessage(role="system", content=quarantined_system_prompt), 
+                                                ChatMessage(role="user", content=" ".join(tool_outputs))])
+                final_output = str(quarantined_response).split("assistant: ", 1)[1]
+                print(f'[Q_LLM] {final_output}')
+            else:
+                final_output = response
+            tool_history.append(parsed_response['tool_name'])
+            print(f"[Tool History]: {tool_history}")
+            prompt = f"Tool history (most recent first): {tool_history}. Do any further tools need to be called? Remember to format your output correctly. As a reminder, here is the original user prompt: {first_prompt}"
     print(f"Final Response: {final_output}")
             
 if __name__ == "__main__":

--- a/dual-llm-mcp/dual_llm.py
+++ b/dual-llm-mcp/dual_llm.py
@@ -142,7 +142,7 @@ The tools are in JSON format and look like this:
 {{"tool_name": {{"tool_description": "description", "args": "{{"arg1": "type"}}"}}}}
 Here are the tools: {json.dumps(all_tools_dict)}
 Tool output can be sent to another LLM for further processing, but no other LLM
-can call tools, only you can.
+can call tools.
 Your output should include: a true or false value on whether a
 tool needs to be called, the tool name, arguments for the tool, a true or
 false value on whether the tool output needs to be sent to a processing LLM or

--- a/dual-llm-mcp/dual_llm.py
+++ b/dual-llm-mcp/dual_llm.py
@@ -3,8 +3,6 @@
 Dual LLM Pattern
 Inspired by Simon Willison's Dual LLM Schema for mitigating prompt injection attacks:
 https://simonwillison.net/2023/Apr/25/dual-llm-pattern/
-
-
 """
 
 import asyncio
@@ -114,7 +112,7 @@ async def run_controller(user_prompt):
     """
     Run the Dual LLM controller
     """
-    mcp_client = EnhancedMCPClient("http://localhost:9006/sse")
+    mcp_client = EnhancedMCPClient("http://localhost:9004/sse")
     print("Connected to MCP server...")
     mcp_tool_spec = McpToolSpec(
         client=mcp_client
@@ -139,20 +137,23 @@ async def run_controller(user_prompt):
 
     # Now: Make a call to a privileged LLM, asking it to take a user prompt and decide what tools to use
     privileged_system_prompt = f"""
-You are an assistant that will decide what tools to call based on a user prompt.
+You are an assistant that can decide what tools to call based on a user prompt.
 The tools will come in JSON format, and will look like this:
 {{"tool_name": {{"tool_description": "description", "args": "{{"arg1": "type"}}"}}}}
 Here are the tools: {json.dumps(all_tools_dict)}
 The output of the tool will be sent to another LLM for further processing.
-Your output should include the tool name, arguments for the tool, and the prompt for
+Your output should include a true or false value deciding whether a
+tool needs to be called, the tool name, arguments for the tool, and the prompt for
 the next processing LLM. Output everything in JSON format, like this:
 {{
+    "tool_necessary": "True" or "False"
     "tool_name": "insert-name-of-tool",
     "args": {{"arg1": "value"}},
     "prompt": "prompt"
 }}
 An example output might look like this:
 {{
+    "tool_necessary": "True"
     "tool_name": "read_document",
     "args": {{"file_name": "notes.txt"}},
     "prompt": "Summarize this document"
@@ -162,28 +163,35 @@ An example output might look like this:
 Look at question.txt
 """
     prompt = user_prompt if user_prompt else demo
-    llm = OpenAI(model='gpt-4o-mini')
-    privileged_response = llm.chat([ChatMessage(role="system", content=privileged_system_prompt), 
-                                    ChatMessage(role="user", content=prompt)])
-    parsed_response = json.loads(str(privileged_response).split('assistant: ', 1)[1])
-    print(f"Received response from privileged LLM: {parsed_response}")
-    # Now we can call the tool, and send the output to a quarantined LLM
-    response = ""
-    
-    for i, tool in enumerate(tools):
-        if tool.metadata.name == parsed_response['tool_name']:
-            response = tool(**parsed_response['args'])
-            response = response.raw_output.content[0].text
-            break
-    
-    quarantined_system_prompt = f"""
-You are a helpful assistant. You will be given information that is output
-from a tool. {parsed_response['prompt']}."""
-    llm = OpenAI(model='gpt-3.5-turbo')
-    quarantined_response = llm.chat([ChatMessage(role="system", content=quarantined_system_prompt), 
-                                    ChatMessage(role="user", content=response)])
-    
-    print(f'[Q_LLM] {str(quarantined_response).split("assistant: ", 1)[1]}')
+    privileged_llm = OpenAI(model='gpt-4o-mini')
+    quarantined_llm = OpenAI(model='gpt-3.5-turbo')
+    tool_necessary = 'True'
+    final_output = ""
+
+    while tool_necessary == 'True':
+        privileged_response = privileged_llm.chat([ChatMessage(role="system", content=privileged_system_prompt), 
+                                        ChatMessage(role="user", content=prompt)])
+        parsed_response = json.loads(str(privileged_response).split('assistant: ', 1)[1])
+        print(f"[P_LLM]: {parsed_response}")
+        tool_necessary = parsed_response['tool_necessary']
+        if tool_necessary == 'True':
+            # Now we can call the tool, and send the output to a quarantined LLM
+            response = ""
+            for i, tool in enumerate(tools):
+                if tool.metadata.name == parsed_response['tool_name']:
+                    response = tool(**parsed_response['args'])
+                    response = response.raw_output.content[0].text
+                    break
+            
+            quarantined_system_prompt = f"""
+        You are a helpful assistant. You will be given information that is output
+        from a tool. {parsed_response['prompt']}."""
+            quarantined_response = quarantined_llm.chat([ChatMessage(role="system", content=quarantined_system_prompt), 
+                                            ChatMessage(role="user", content=response)])
+            final_output = str(quarantined_response).split("assistant: ", 1)[1]
+            prompt = f"Tool {parsed_response['tool_name']} has been called and its output has been processed. Do any further tools need to be called? Remember to format your output correctly."
+            print(f'[Q_LLM] {final_output}')
+    print(f"Final Response: {final_output}")
             
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Demo client for prompt injection")


### PR DESCRIPTION
The initial versions of `dual_llm.py` and `combined_client.py` passed through the full schema just once, no looping:
Controller -> Privileged LLM -> Controller -> Quarantined LLM -> Done
This served as a proof of concept for the Dual LLM schema and Dual LLM + Logging schema.
This PR includes code to add looping, so the Privileged LLM can decide whether or not to call further tools after the first tool is called.